### PR TITLE
Whitelist enhancement

### DIFF
--- a/classes/DetectionRuleConverter.py
+++ b/classes/DetectionRuleConverter.py
@@ -50,8 +50,8 @@ class DetectionRuleConverter(object):
                     tableindex = search.find('| table')
                     search = search[:tableindex] + "| search NOT [| inputlookup " + file_name + "] " + search[tableindex:]
                 elif '| stats' in search:
-                    tableindex = search.find('| stats')
-                    search = search[:tableindex] + "| search NOT [| inputlookup " + file_name + "] " + search[tableindex:]
+                    statsindex = search.find('| stats')
+                    search = search[:statsindex] + "| search NOT [| inputlookup " + file_name + "] " + search[statsindex:]
                 else:
                     search = search[:-1] + " | search NOT [| inputlookup " + file_name + "] "
             


### PR DESCRIPTION
Hi P4T12ICK,

Some findings and enhancements:

-lookupfile names with "(" or ")" are invalid in Splunk, thats why i just delete these characters for the naming of the whitelist (e.g. sysmon_logon_scripts_userinitmprlogonscript.yml)

-sometimes the "interesting fields" int the table command are not enough to whitelist, thats why i would place the whitelist in front of the table or transforming command (e.g sysmon_susp_file_characteristics.yml)

The behaviour of the 2nd part would also be nice to control in the config of Sigma2SplunkAlert, like using a "add_whitelist_in_front" in the search transformation configuration. So a user is able to choose what suites him the most.

a2tf