### PR TITLE
introducing allow_skew to config and output

### DIFF
--- a/classes/UseCase.py
+++ b/classes/UseCase.py
@@ -14,6 +14,7 @@ class UseCase:
         self.description = sigma_uc["description"]
         self.app = config["app"]
         self.cron_schedule = config["cron_schedule"]
+        self.allow_skew = config["allow_skew"]
         self.earliest_time = config["earliest_time"]
         self.latest_time = config["latest_time"]
         self.schedule_window = config["schedule_window"]

--- a/templates/template
+++ b/templates/template
@@ -31,6 +31,8 @@ alert.track = 1
 alert.expires = 24h
 counttype = number of events
 cron_schedule = {{ uc.cron_schedule }}
+{% if uc.allow_skew!="" %}allow_skew = {{ uc.allow_skew}}
+{% endif %}
 description = {{ uc.description }}
 dispatch.earliest_time = {{ uc.earliest_time }}
 dispatch.latest_time = {{ uc.latest_time }}


### PR DESCRIPTION
Hi P4T12ICK

As we plan to use a lot (thousands) of searches on the same search head, we are using skewing to distribute our searches. The time frame which is searched stays the same.

Therefore i suggest to implement the "allow_skew" option in the template and therefore in the savedsearches output.

I hope this feature fits you as well.

a2tf