### PR TITLE
introducing alert_manager as alert action

### DIFF
--- a/classes/AlertManager.py
+++ b/classes/AlertManager.py
@@ -1,0 +1,43 @@
+class AlertManager:
+    
+    def __init__(self, alertmanager_config, sigma_uc):
+        # mandatory values
+        if 'auto_previous_resolve' in alertmanager_config:
+            self.auto_previous_resolve = alertmanager_config['auto_previous_resolve']
+        else:
+            self.auto_previous_resolve = 0
+        if 'auto_subsequent_resolve' in alertmanager_config:
+            self.auto_subsequent_resolve = alertmanager_config['auto_subsequent_resolve']
+        else:
+            self.auto_subsequent_resolve = 0
+        if 'auto_suppress_resolve' in alertmanager_config:
+            self.auto_suppress_resolve = alertmanager_config['auto_suppress_resolve']
+        else:
+            self.auto_suppress_resolve = 0
+        if 'auto_ttl_resove' in alertmanager_config:
+            self.auto_ttl_resove = alertmanager_config['auto_ttl_resove']
+        else:
+            self.auto_ttl_resove = 0
+        
+        # optional values
+        if 'title' in alertmanager_config:
+            self.title = alertmanager_config['title']
+        if "display_fields" in alertmanager_config:
+            self.display_fields = alertmanager_config["display_fields"]
+        if "tags" in alertmanager_config:
+            self.tags = alertmanager_config["tags"]
+        if "auto_assign_owner" in alertmanager_config:
+            self.auto_assign_owner = alertmanager_config["auto_assign_owner"]
+        if "append_incident" in alertmanager_config:
+            self.append_incident = alertmanager_config["append_incident"]
+        if "urgency" in alertmanager_config:
+            self.urgency = alertmanager_config["urgency"]
+        if "impact" in alertmanager_config:
+            self.impact = alertmanager_config["impact"]
+        if "category" in alertmanager_config:
+            self.category = alertmanager_config["category"]
+        if "subcategory" in alertmanager_config:
+            self.subcategory = alertmanager_config["subcategory"]
+        if "notification_scheme" in alertmanager_config:
+            self.notification_scheme = alertmanager_config["notification_scheme"]
+            

--- a/classes/UseCase.py
+++ b/classes/UseCase.py
@@ -4,6 +4,7 @@ from subprocess import DEVNULL
 from .TriggeredAlert import TriggeredAlert
 from .EMail import EMail
 from .SummaryIndex import SummaryIndex
+from .AlertManager import AlertManager
 
 
 class UseCase:
@@ -39,11 +40,16 @@ class UseCase:
             self.schedule_window = config["schedule_window"]
 
         # default values
-        self.alert_email = 0
+        self.action_alert_email = 0
+        self.action_alert_manager = 0
 
         # alert actions
         if 'email' in config["alert_action"]:
-            self.alert_email = 1
+            self.action_email = 1
             self.email = EMail(config["alert_action"]["email"], sigma_uc)
         if 'summary_index' in config["alert_action"]:
             self.summary_index = SummaryIndex(config["alert_action"]["summary_index"])
+        if 'alert_manager' in config["alert_action"]:
+            self.action_alert_manager = 1
+            self.alert_manager = AlertManager(config["alert_action"]["alert_manager"], sigma_uc)
+

--- a/templates/template
+++ b/templates/template
@@ -1,7 +1,7 @@
 {% for uc in uc_list %}
 # Generated with Sigma2SplunkAlert
 [{{ uc.title }}]
-{% if uc.alert_email==1 %}action.email = 1
+{% if uc.action_email==1 %}action.email = 1
 {% if uc.email.result_link==1 %}action.email.include.results_link = {{ uc.email.result_link }}
 {% endif %}
 {% if uc.email.view_link==1 %}action.email.include.view_link = {{ uc.email.view_link }}
@@ -24,6 +24,30 @@ action.email.subject.alert = {{ uc.email.subject }}
 action.email.to = {{ uc.email.to }}
 action.email.message.alert = {{ uc.email.message | replace("%title%",uc.title) | replace("%status%",uc.status) | replace("%description%",uc.description) | replace("%references%",uc.references) | replace("%tags%",uc.tags) | replace("%author%",uc.author) | replace("%date%",uc.date) | replace("%falsepositives%",uc.falsepositives) | replace("%level%",uc.level) | replace("%mitre%",uc.mitreBlock) | replace("%fields%",uc.email.field_block) | replace("|","\\\n") }}
 action.email.useNSSubject = 1
+{% endif %}
+{% if uc.action_alert_manager==1 %}action.alert_manager = 1
+{% if uc.alert_manager.title is defined %}action.alert_manager.param.title = {{ uc.alert_manager.title }}
+{% endif %}
+{% if uc.alert_manager.auto_assign_owner is defined %}action.alert_manager.param.auto_assign_owner = {{ uc.alert_manager.auto_assign_owner }}
+{% endif %}
+action.alert_manager.param.auto_previous_resolve = {{ uc.alert_manager.auto_previous_resolve }}
+action.alert_manager.param.auto_subsequent_resolve = {{ uc.alert_manager.auto_subsequent_resolve }}
+action.alert_manager.param.auto_suppress_resolve = {{ uc.alert_manager.auto_suppress_resolve }}
+action.alert_manager.param.auto_ttl_resove = {{ uc.alert_manager.auto_ttl_resove }}
+{% if uc.alert_manager.display_fields is defined %}action.alert_manager.param.display_fields = {{ uc.alert_manager.display_fields }}
+{% endif %}
+{% if uc.alert_manager.urgency is defined %}action.alert_manager.param.urgency = {{ uc.alert_manager.urgency }}
+{% endif %}
+{% if uc.alert_manager.impact is defined %}action.alert_manager.param.impact = {{ uc.alert_manager.impact }}
+{% endif %}
+{% if uc.alert_manager.category is defined %}action.alert_manager.param.category = {{ uc.alert_manager.category }}
+{% endif %}
+{% if uc.alert_manager.subcategory is defined %}action.alert_manager.param.subcategory = {{ uc.alert_manager.subcategory }}
+{% endif %}
+{% if uc.alert_manager.tags is defined %}action.alert_manager.param.tags = {{ uc.alert_manager.tags }}
+{% endif %}
+{% if uc.alert_manager.notification_scheme is defined %}action.alert_manager.param.notification_scheme = {{ uc.alert_manager.notification_scheme }}
+{% endif %}
 {% endif %}
 alert.severity = 1
 alert.suppress = 0


### PR DESCRIPTION
Hi Patrick

Here is my version for review. It allows you to use "Alert Manager" as alert action. These settings are available in the Sigma2SplunkAlert config file:

```
alert_action:
    alert_manager:
        title: ''
        auto_assign_owner: ''
        append_incident: ''
        auto_previous_resolve: '1'
        auto_subsequent_resolve: '1'
        auto_suppress_resolve: '1'
        auto_ttl_resove: '1'
        display_fields: ''
        urgency: ''
        impact: ''
        category: ''
        subcategory: ''
        tags: ''
        notification_scheme: ''
```
These 4  parameters are needed to generate the action:

```
        auto_previous_resolve: '1'
        auto_subsequent_resolve: '1'
        auto_suppress_resolve: '1'
        auto_ttl_resove: '1'
```
And are defaulted to "0". The rest of the parameters are set with defaults from alert_manager if not set in savedsearches.conf.

I extended the template with the according parameters, because I think some people like to use both actions at the same time (alert_manager & email).

a2tf