### PR TITLE
Possibility of installation via pip added

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ and generates a savedsearches.conf configuration. More information about the Sig
 Sigma2SplunkAlert needs Sigma for converting the Sigma detection rules into Splunk searches. Sigma needs to be installed and part of the environment variables. Furthermore, Python >= 3.5, PyYAML and Jinja2 is needed.
 The Sigma2SplunkAlert was tested with Splunk version 7.2.5. If you find some incompatibility to previous Splunk versions, open an issue and I will try to add the support as soon as possible.
 
+# Installation
+
+You can use pip to install sigma2splunkalert  
+`pip install git+https://github.com/P4T12ICK/Sigma2SplunkAlert.git`
+
 # Usage
 ````
 usage: sigma2splunkalert [-h] [--config CONFIG] [--sigma-config SIGMA_CONFIG]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,35 @@
+from setuptools import setup
+
+setup (
+    name='sigma2splunkalert',
+    version='0.0.1',
+    packages=[''],
+    url='',
+    license='MIT',
+    author='',
+    author_email='',
+    description='sigma2splunkalert',
+    data_files=[
+        ('bin/config' , [
+            'config/config.yml'
+        ]),
+        ('bin/templates' , [
+            'templates/template'
+        ]),
+        ('bin/sigma_config' , [
+            'sigma_config/splunk-all.yml'
+        ]),
+        ('bin/classes' , [
+            'classes/AlertManager.py',
+            'classes/DetectionRuleConverter.py',
+            'classes/EMail.py',
+            'classes/SummaryIndex.py',
+            'classes/TriggeredAlert.py',
+            'classes/UseCase.py'
+        ])
+    ],
+    install_requires=['pyYaml','jinja2','sigmatools'],
+    scripts=[
+        'sigma2splunkalert'
+    ]
+)

--- a/sigma2splunkalert
+++ b/sigma2splunkalert
@@ -33,14 +33,16 @@ def main(argv):
     if cmdargs.config:
         converter_config_path = cmdargs.config
     else:
-        converter_config_path = 'config/config.yml'
+        #converter_config_path = 'config/config.yml'
+        converter_config_path = os.path.join(os.path.dirname ( __file__ ), 'config/config.yml')
 
     # cmdargs Sigma Configuration
     if cmdargs.sigma_config:
         sigma_config_path = cmdargs.sigma_config
     else:
-        sigma_config_path = 'sigma_config/splunk-all.yml'
-        
+        #sigma_config_path = 'sigma_config/splunk-all.yml'
+        sigma_config_path =  os.path.join(os.path.dirname ( __file__ ), 'sigma_config/splunk-all.yml')
+
     # cmdargs template Configuration
     if cmdargs.template:
         template_path = cmdargs.template
@@ -79,18 +81,19 @@ def main(argv):
             detection_rule = UseCase(sigma_rule, sigma2splunkalertconfig, splunk_search)
             detection_rules.append(detection_rule)
 
-    
+
     # Use Jinja2 Templating for create configuration
     if cmdargs.template:
         file_loader = FileSystemLoader(os.path.dirname(template_path))
     else:
-        file_loader = FileSystemLoader('templates')
-        
+        #file_loader = FileSystemLoader('templates')
+        file_loader = FileSystemLoader(os.path.join( os.path.dirname ( __file__ ), 'templates' ))
+
     env = Environment(loader=file_loader)
     env.trim_blocks = True
     env.lstrip_blocks = True
     env.rstrip_blocks = True
-    
+
     if cmdargs.template:
         template = env.get_template(os.path.basename(template_path))
 


### PR DESCRIPTION
Hi Patrick,

I added a simple setup.py to make it make it easier to use sigma2splunkalert.
In order to avoid conflicts with other packages I thought about moving all configuration files into a unique folder (like etc/sigma2splunkalert). But I didn't want to mess around with your folders. If it’s okay for you I can do this in a separate PR.